### PR TITLE
add middleware for /api/foo that shows same problem

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { Client } from "pg";
+
+export function middleware(request: NextRequest) {
+
+  if (request.nextUrl.pathname.startsWith('/api/foo')) {
+    const pg = new Client();
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+}

--- a/pages/api/foo.ts
+++ b/pages/api/foo.ts
@@ -1,0 +1,9 @@
+import { NextFetchEvent, NextRequest } from "next/server";
+
+export const config = {
+  runtime: "edge",
+};
+
+export default function handler(req: NextRequest, context: NextFetchEvent) {
+  return new Response("This will never be returned, thanks to middleware.", { status: 200 });
+}


### PR DESCRIPTION
Access `/api/foo` (which would be harmless by itself) to trigger the middleware, which then also crashes.